### PR TITLE
Use tifffile to mmap scroll .tif files

### DIFF
--- a/VolumeAnnotate.py
+++ b/VolumeAnnotate.py
@@ -8,7 +8,7 @@ from eventHandlers import *
 sessionId0 = time.strftime("%Y%m%d%H%M%S") 
 sessionId = sessionId0 + "autosave.pkl"
 
-
+VOLPKG = False
 
 class App(QWidget):
     def __init__(self, *args, **kwargs):
@@ -20,9 +20,11 @@ class App(QWidget):
         # set to full screen
         # self.showFullScreen()
         print(folder)
-        self.volpkg = Volpkg(folder, sessionId0)
-
-        self._frame_list = self.volpkg.tifstack
+        if VOLPKG:
+            self.volpkg = Volpkg(folder, sessionId0)
+            self._frame_list = self.volpkg.tifstack
+        else:
+            self._frame_list = load_tif(folder)
         self.TheData = Loader(self._frame_list)
 
         # set grid layout

--- a/VolumeAnnotate.py
+++ b/VolumeAnnotate.py
@@ -23,9 +23,7 @@ class App(QWidget):
         self.volpkg = Volpkg(folder, sessionId0)
 
         self._frame_list = self.volpkg.tifstack
-        shape = cv2.imread(self._frame_list[0]).shape
-        self.TheData = Loader(shape, 3, "mmap_cache.mmap", self._frame_list)
-        #self._frame_list = load_tif(folder)
+        self.TheData = Loader(self._frame_list)
 
         # set grid layout
         self.layout = QGridLayout()

--- a/helpers.py
+++ b/helpers.py
@@ -195,10 +195,11 @@ class Volpkg(object):
 
 class Loader:
 	def __init__(self, tifStack):
-		self.mappings = []
+		self.mappings = dict()
 		self.tifStack = tifStack
 		for f in sorted(tifStack):
-			self.mappings.append(tifffile.memmap(f, mode='r'))
+			idx = int(os.path.basename(f).split('.')[0])
+			self.mappings[idx] = tifffile.memmap(f, mode='r')
 
 	#overload index operator
 	def __getitem__(self, slice):

--- a/mImage.py
+++ b/mImage.py
@@ -119,13 +119,11 @@ class mImage(object):
 		x0 = int(self.offset[0])
 		y0 = int(self.offset[1])
 
-		
-
 		x1 = int(self.imshape[0]*self.scale)
 		y1 = int(self.imshape[1]*self.scale)
-		img = self.TheData[frame_index, x0:x1+x0, y0:y0+y1]
 
-		img = self.getProcImg(img)
+		img = self.getProcImg(index=frame_index)
+		img = img[x0:x1+x0, y0:y0+y1]
 		if show_annotations:
 			self.showAnnotations(img, frame_index, y0, x0, self.scale)
 		#resize the image by interpolation
@@ -134,26 +132,24 @@ class mImage(object):
 		
 		#CONVERT to pixmap
 		data = img
-		bytesperline = 3 * data.shape[1]
+		bytesperline = data.shape[1]
 
-		qimg = QImage(data, data.shape[1], data.shape[0], bytesperline, QImage.Format_RGB888)
+		qimg = QImage(data, data.shape[1], data.shape[0], bytesperline, QImage.Format_Grayscale8)
 
 		pixmap = QPixmap.fromImage(qimg)
 		return pixmap
 
 
 	def getProcImg(self, img=None, index=None):
-		if index != None:
+		if img is None:
 			img = self.TheData.getFrame(index)
-
-	
+		img = np.copy(img)
+		img //=255
+		img = img.astype(np.uint8)
 		#invert the image
 		if self.invert:
 			img = cv2.bitwise_not(img)
 		# #apply contrast filter
 		img = cv2.convertScaleAbs(img, alpha=self.contrast/5,beta=100)
-		
 		return img
 	
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy
 opencv-python
 PyQt5
-
+tifffile


### PR DESCRIPTION
`tifffile` allows for the contents of `.tiff` files to have their contents `mmap`ed directly into memory, so I've converted the loader to use that. The scrolls are 16 bit grayscale, so I changed `getImg` to work with grayscale images, and for `getProcImg` to downsample to 8 bits, since opencv functions like convertScaleAbs assume 8 bits.
